### PR TITLE
Fix React 15.5 warnings.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React from 'react'; // eslint-disable-line no-unused-vars
 import hoistStatics from 'hoist-non-react-statics';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 const getDisplayName = Component => (
   Component.displayName || Component.name || 'Component'
@@ -21,10 +23,10 @@ export function injectDeps(context, _actions) {
   }
 
   return function (Component) {
-    const ComponentWithDeps = React.createClass({
+    const ComponentWithDeps = createReactClass({
       childContextTypes: {
-        context: React.PropTypes.object,
-        actions: React.PropTypes.object
+        context: PropTypes.object,
+        actions: PropTypes.object
       },
 
       getChildContext() {
@@ -51,7 +53,7 @@ const defaultMapper = (context, actions) => ({
 
 export function useDeps(mapper = defaultMapper) {
   return function (Component) {
-    const ComponentUseDeps = React.createClass({
+    const ComponentUseDeps = createReactClass({
       render() {
         const {context, actions} = this.context;
         const mappedProps = mapper(context, actions);
@@ -65,8 +67,8 @@ export function useDeps(mapper = defaultMapper) {
       },
 
       contextTypes: {
-        context: React.PropTypes.object,
-        actions: React.PropTypes.object
+        context: PropTypes.object,
+        actions: PropTypes.object
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   },
   "dependencies": {
     "babel-runtime": "6.x.x",
-    "hoist-non-react-statics": "1.x.x"
+    "create-react-class": "^15.5.3",
+    "hoist-non-react-statics": "1.x.x",
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
- Migrating from React.PropTypes
  [https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes](url)
- Migrating from React.createClass 
  [https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass](url)